### PR TITLE
Revert duration input to string

### DIFF
--- a/nodes/i2v2_node.py
+++ b/nodes/i2v2_node.py
@@ -18,7 +18,7 @@ class I2V2Node(BaseTaskNode):
                 "end_image": ("IMAGE",),
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/nodes/i2v3_node.py
+++ b/nodes/i2v3_node.py
@@ -21,7 +21,7 @@ class I2V3Node(BaseTaskNode):
                 "image_3": ("IMAGE",),
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/nodes/i2v_node.py
+++ b/nodes/i2v_node.py
@@ -17,7 +17,7 @@ class I2VNode(BaseTaskNode):
                 "start_image": ("IMAGE",),
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/nodes/i2vr_node.py
+++ b/nodes/i2vr_node.py
@@ -24,7 +24,7 @@ class I2VRNode(BaseTaskNode):
                 "element_2__reference_image_1": ("IMAGE",),
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/nodes/t2v_node.py
+++ b/nodes/t2v_node.py
@@ -16,7 +16,7 @@ class T2VNode(BaseTaskNode):
             "optional": {
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/nodes/task_utils.py
+++ b/nodes/task_utils.py
@@ -253,7 +253,7 @@ class BaseTaskNode:
         }
         
         if duration is not None:
-            arguments["duration"] = duration
+            arguments["duration"] = str(duration)
             
         if generate_audio is not None:
             arguments["generate_audio"] = generate_audio

--- a/nodes/v2v_node.py
+++ b/nodes/v2v_node.py
@@ -17,7 +17,7 @@ class V2VNode(BaseTaskNode):
                 "video": ("VIDEO",),
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/nodes/v2vr_node.py
+++ b/nodes/v2vr_node.py
@@ -24,7 +24,7 @@ class V2VRNode(BaseTaskNode):
                 "element_2__reference_image_1": ("IMAGE",),
                 "aspect_ratio": ("STRING", {"default": ""}),
                 "resolution": ("STRING", {"default": ""}),
-                "duration": ("INT", {"default": 5, "min": 1, "max": 60}),
+                "duration": ("STRING", {"default": "5"}),
                 "generate_audio": ("BOOLEAN", {"default": True}),
             },
             "hidden": {"extra_pnginfo": "EXTRA_PNGINFO", "unique_id": "UNIQUE_ID"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deepgen-api"
 description = "ComfyUI nodes for DeepGen API"
-version = "1.2.12"
+version = "1.2.13"
 license = {file = "LICENSE"}
 dependencies = ["requests", "opencv-python"]
 


### PR DESCRIPTION
- Changed duration input type in all video nodes back from INT to STRING.\n- Ensured the value is cast to a string `str(duration)` in `task_utils.py` before it is sent to the DeepGen API.\n- Bumped version to 1.2.13.